### PR TITLE
(SIMP-255) Modified stunnel's default pid dir.

### DIFF
--- a/build/pupmod-stunnel.spec
+++ b/build/pupmod-stunnel.spec
@@ -1,7 +1,7 @@
 Summary: Stunnel Puppet Module
 Name: pupmod-stunnel
 Version: 4.2.0
-Release: 8
+Release: 9
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -57,6 +57,11 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Jul 21 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-9
+- Moved stunnel's default pid location back to /var/run/stunnel/stunnel.pid.
+- Stunnel's init script now only creates and chowns the pid file directory
+  if it does not exist.
+
 * Wed Jul 01 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-8
 - Stunnel's default pid file location moved from /var/run/stunnel/stunnel.pid
   to /var/run/stunnel.pid

--- a/files/stunnel
+++ b/files/stunnel
@@ -33,9 +33,12 @@ group=`grep "setgid[[:space:]]*=" /etc/stunnel/stunnel.conf | sed -e 's/setgid[[
 
 # Set the SELinux Contexts Properly
 if [ -z ${pidfile} ]; then
-    mkdir -p --context=system_u:object_r:stunnel_var_run_t:s0 `dirname ${pidfile}`
-    chown ${user}:${group} `dirname ${pidfile}`
-    pidfile="/var/run/stunnel.pid";
+    piddir=`dirname ${pidfile}`
+    if [ ! -d ${piddir} ]; then
+      mkdir -p --context=system_u:object_r:stunnel_var_run_t:s0 ${piddir}
+      chown ${user}:${group} `dirname ${pidfile}`
+    fi
+    pidfile="/var/run/stunnel/stunnel.pid";
 fi
 if [ -n $chroot ]; then
     mkdir -p --context=system_u:object_r:stunnel_var_run_t:s0 ${chroot}`dirname ${pidfile}`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 #
 # [*pid*]
 #   Type: Absolute Path
-#   Default: '/var/run/stunnel.pid'
+#   Default: '/var/run/stunnel/stunnel.pid'
 #
 #   The PID file. Relative to the chroot jail! Let the startup script
 #   handle it by default.
@@ -116,7 +116,7 @@
 #
 class stunnel (
   $chroot = '/var/stunnel',
-  $pid = '/var/run/stunnel.pid',
+  $pid = '/var/run/stunnel/stunnel.pid',
   $setuid = 'stunnel',
   $setgid = 'stunnel',
   $stunnel_debug = 'err',


### PR DESCRIPTION
Moved it back to /var/run/stunnel/stunnel.pid by default.
The init script only creates and chowns the pid dir if it does
not exist.

SIMP-255 #close Stunnel pid dir
