### PR TITLE
(SIMP-1167) Found a variable reference issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jul 08 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.7-0
+- Incorrectly referenced the global $::use_simp_pki in ::stunnel
+
 * Wed Jul 06 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.6-0
 - Ensure that the PKI copy is performed prior to copying the system cacerts
   into the stunnel chroot.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -358,7 +358,7 @@ class stunnel (
       notify  => Service['stunnel']
     }
 
-    if $::use_simp_pki {
+    if $use_simp_pki {
       Class['pki'] ~> File["${_chroot}/etc/pki/cacerts"]
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "author": "simp",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",


### PR DESCRIPTION
The last release was referencing the top level $::simp_pki instead of
$simp_pki in ::stunnel.

SIMP-1167 #comment Fix variable reference

Change-Id: I87be5df7cfdb1acde1a9aedac9e7307a8d0c490b