### PR TITLE
(SIMP-1167) Ensure that ::pki preceeds ::stunnel

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,6 +211,7 @@ class stunnel (
 
   if $use_simp_pki {
     include '::pki'
+    Class['pki'] -> Class['stunnel']
   }
 
   if $use_haveged {
@@ -356,10 +357,6 @@ class stunnel (
       mode    => '0640',
       recurse => true,
       notify  => Service['stunnel']
-    }
-
-    if $use_simp_pki {
-      Class['pki'] ~> File["${_chroot}/etc/pki/cacerts"]
     }
 
     File["${_chroot}/etc/resolv.conf"] -> Service['stunnel']


### PR DESCRIPTION
The entire PKI module needs to be executed prior to the stunnel module
if it is being used.

SIMP-1167 #comment issue discovered during testing

Change-Id: Ic28ee2fb5cec448d93eebd9b06e9494b67c599eb