### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Fri Jul 08 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.7-0
 - Incorrectly referenced the global $::use_simp_pki in ::stunnel
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -3,5 +3,5 @@ Requires: pupmod-simp-haveged >= 0.3.0
 Requires: pupmod-simp-iptables >= 2.0.0-0
 Requires: pupmod-simp-openldap >= 2.0.0-0
 Requires: pupmod-simp-pki >= 3.0.0-0
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-stunnel-test >= 0.0.1

--- a/manifests/add.pp
+++ b/manifests/add.pp
@@ -432,7 +432,7 @@ define stunnel::add(
 
   compliance_map()
 
-  concat_fragment { "stunnel+stunnel_${name}.conf":
+  simpcat_fragment { "stunnel+stunnel_${name}.conf":
     content => template('stunnel/stunnel.erb')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -218,13 +218,13 @@ class stunnel (
     include '::haveged'
   }
 
-  concat_build { 'stunnel':
+  simpcat_build { 'stunnel':
     order   => ['*.conf'],
     target  => '/etc/stunnel/stunnel.conf',
     require => Package['stunnel']
   }
 
-  concat_fragment { 'stunnel+0global.conf':
+  simpcat_fragment { 'stunnel+0global.conf':
     content => template('stunnel/stunnel.erb')
   }
 
@@ -266,7 +266,7 @@ class stunnel (
     mode      => '0640',
     notify    => Service['stunnel'],
     require   => Package['stunnel'],
-    subscribe => Concat_build['stunnel'],
+    subscribe => Simpcat_build['stunnel'],
     tag       => 'firstrun',
     audit     => content
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "4.2.7",
+  "version": "5.0.0",
   "author": "simp",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,7 @@ describe 'stunnel' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_user('stunnel') }
         it { is_expected.to contain_package('stunnel').that_comes_before('Service[stunnel]') }
-        it { is_expected.to contain_concat_fragment('stunnel+0global.conf') }
+        it { is_expected.to contain_simpcat_fragment('stunnel+0global.conf') }
         it { is_expected.to contain_class('haveged') }
 
         context "alternate gid" do

--- a/spec/classes/vartest_init_spec.rb
+++ b/spec/classes/vartest_init_spec.rb
@@ -17,7 +17,7 @@ def variable_test(key,val,opts={})
     else
 
       it do
-        is_expected.to contain_concat_fragment('stunnel+0global.conf').with({
+        is_expected.to contain_simpcat_fragment('stunnel+0global.conf').with({
           'content' => /^\s*#{opts[:key_str]} = #{opts[:val_str]}\n/
         })
       end
@@ -34,7 +34,7 @@ describe 'stunnel' do
         it { is_expected.to compile.with_all_deps }
 
         it do
-          is_expected.to contain_concat_fragment('stunnel+0global.conf').with({
+          is_expected.to contain_simpcat_fragment('stunnel+0global.conf').with({
             'content' => /.*chroot = \/var\/stunnel\nsetgid = stunnel\nsetuid = stunnel\ndebug = err\n.*/
           })
         end

--- a/spec/defines/vartest_add_spec.rb
+++ b/spec/defines/vartest_add_spec.rb
@@ -15,13 +15,13 @@ def variable_test(title,key,val,opts={})
 
     if opts[:err] then
       it do
-        expect { should contain_concat_fragment("stunnel+stunnel_#{title}.conf") }.to
+        expect { should contain_simpcat_fragment("stunnel+stunnel_#{title}.conf") }.to
           raise_error(opts[:err],opts[:errmsg])
       end
     else
 
       it do
-        should contain_concat_fragment("stunnel+stunnel_#{title}.conf").with({
+        should contain_simpcat_fragment("stunnel+stunnel_#{title}.conf").with({
           'content' => opts[:content]
         })
       end

--- a/templates/stunnel.erb
+++ b/templates/stunnel.erb
@@ -8,7 +8,7 @@ bool_translate = {
 
 # This is just a stupid way to differentate between global options and
 # service options
-if scope.function_defined(['$setgid']) then
+if has_variable?('setgid') then
   stunnel_conf << ["# This file managed by Puppet. Manual changes will be erased!\n"]
 
   if @_chroot then


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'stunnel'
