### PR TITLE
SIMP-2319 Fix haveged dependency in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": [
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
stunnel is pointing to simp-puppet-haveged when it should be pointing to simp-haveged. This is causing some of the puppet tooling to throw errors and it will cause problems now that the puppet loader cares about dependencies in metadata.json

SIMP-2319 #close