### PR TITLE
(SIMP-2534) Remove redundant parameter $libwrap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Updated pki::copy to use the new scheme.
 - Application certs now managed in /etc/pki/simp_apps/stunnel/x509
 - Removed parameters from README because we are puppet-strings-ified.
+- Removed redundant parameter $libwrap
 
 * Thu Dec 29 2016 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Updated the stunnel::connection connect parameter to take an array

--- a/manifests/connection.pp
+++ b/manifests/connection.pp
@@ -213,7 +213,6 @@ define stunnel::connection (
   Optional[String]                             $protocol_password       = undef,
   Boolean                                      $delay                   = false,
   Optional[Integer]                            $engine_num              = undef,
-  Boolean                                      $libwrap                 = false,
   Optional[String]                             $exec                    = undef,
   Array[String]                                $execargs                = [],
   Boolean                                      $pty                     = false,
@@ -304,7 +303,7 @@ define stunnel::connection (
     }
   }
 
-  if $libwrap and !$client and $tcpwrappers {
+  if !$client and $tcpwrappers {
     include '::tcpwrappers'
 
     tcpwrappers::allow { "allow_stunnel_${name}":

--- a/spec/defines/connection_spec.rb
+++ b/spec/defines/connection_spec.rb
@@ -27,7 +27,6 @@ describe 'stunnel::connection' do
           let(:title){ 'nfs' }
           let(:params){{
             :tcpwrappers  => true,
-            :libwrap      => true,
             :client       => false,
             :connect      => [2049],
             :accept       => 20490,


### PR DESCRIPTION
The functionality of this parameter is duplicated by our tcpwrappers
global catalyst, so $libwrap has been removed.

SIMP-2534 #close