### PR TITLE
(SIMP-4016) Stunnel Instance Safety Updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,3 +115,12 @@ acceptance-default:
   <<: *setup_bundler_env
   script:
     - bundle exec rake beaker:suites[default]
+
+acceptance-default-fips:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - BEAKER_fips=yes bundle exec rake beaker:suites[default]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,8 @@
     - bundle exec rake check:test_file
     - bundle exec rake pkg:check_version
     - bundle exec rake compare_latest_tag
+    - bundle exec rake lint
+    - puppet module build
 
 .spec_tests: &spec_tests
   script:
@@ -120,7 +122,9 @@ acceptance-default-fips:
   stage: acceptance
   tags:
     - beaker
+  variables:
+    BEAKER_fips: 'yes'
   <<: *cache_bundler
   <<: *setup_bundler_env
   script:
-    - BEAKER_fips=yes bundle exec rake beaker:suites[default]
+    - bundle exec rake beaker:suites[default]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,117 @@
-#
 ---
-puppet-syntax:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    key: "$CI_BUILD_REF_NAME"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - gem install bundler
+    - rm -f Gemfile.lock
+    - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
+
+.syntax_checks: &syntax_checks
   script:
-    - bundle install
     - bundle exec rake syntax
-puppet-lint:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake compare_latest_tag
+
+.spec_tests: &spec_tests
   script:
-    - bundle install
-    - bundle exec rake lint
-puppet-metadata:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
-  script:
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
-  script:
-    - bundle install
     - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
+
+stages:
+  - syntax
+  - unit
+  - acceptance
+  - deploy
+
+puppet-syntax:
+  stage: syntax
   tags:
     - docker
-  image: ruby:2.2
-  allow_failure: true
-  script:
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
+  image: ruby:2.4
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
+
+# Puppet 4
+unit-ruby-2.1.9:
+  stage: unit
   tags:
     - docker
-  image: ruby:2.3
-  allow_failure: true
-  script:
-    - bundle install
-    - bundle exec rake spec
+  image: ruby:2.1.9
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+# Puppet 5
+unit-ruby-2.4.1:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 puppet4.7-syntax:
-  stage: test
+  stage: syntax
   tags:
     - docker
   image: ruby:2.1
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script:
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+  variables:
+    PUPPET_VERSION: '4.7'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
 
-acceptance-test:
-  stage: test
+unit-puppet4.7-ruby-2.1:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '4.7'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+puppet5-syntax:
+  stage: syntax
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
+
+unit-puppet5-ruby-2.4:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+acceptance-default:
+  stage: acceptance
   tags:
     - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
   script:
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake beaker:suites
+    - bundle exec rake beaker:suites[default]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.1
+- Isolated the 'instance' logic away from the 'connection' logic
+- Added a private 'monolithic' class that arranges everything properly for the
+  legacy stunnel connections
+- Ensure that 'instances' and 'connections' do not conflict by using a
+  'reserve_port' class
+- Add a native type that will clean up all instances that would be randomly
+  created by the 'stunnel::instance' defines and will come before both legacy
+  and new stunnel connections so that we do not have random left over services
+  that may conflict with new services
+
 * Fri Nov 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.2.1
 - Add feature to systemd init script to kill stunnels started from
   the previous version of the module

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.1
+* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0
 - Isolated the 'instance' logic away from the 'connection' logic
 - Added a private 'monolithic' class that arranges everything properly for the
   legacy stunnel connections

--- a/lib/puppet/provider/stunnel_instance_purge/purge.rb
+++ b/lib/puppet/provider/stunnel_instance_purge/purge.rb
@@ -1,0 +1,88 @@
+Puppet::Type.type(:stunnel_instance_purge).provide(:purge) do
+  desc 'Provider for purging expired ``stunnel::instance`` resources'
+
+  confine :kernel => 'Linux'
+
+  def change_to_s
+    return @state_msg
+  end
+
+  def dirs
+    # Shortcut for preventing a change notification
+    @state_msg = resource[:dirs]
+
+    begin
+
+      @system_services = Puppet::Resource::indirection.search('Service', {}).select do |s|
+        s.title =~ %r(^#{@resource[:name]})
+      end
+
+    rescue Puppet::Error
+      @system_services = nil
+    end
+
+    if @system_services
+      matching_catalog_services = @resource.catalog.resources.find_all do |res|
+        res.is_a?(Puppet::Type.type(:service)) && res[:name] =~ %r(^#{@resource[:name]})
+      end
+
+      system_service_names = @system_services.map(&:title)
+      matching_catalog_service_names = matching_catalog_services.map(&:name)
+
+      # Handle systemd
+      if system_service_names.first && system_service_names.first.split('.')[-1] == 'service'
+        matching_catalog_service_names.map!{|n| n = n + '.service'}
+      end
+
+      rogue_services = system_service_names - matching_catalog_service_names
+
+      if rogue_services && !rogue_services.empty?
+        @to_purge = rogue_services
+
+        if @resource[:verbose] || @resource[:noop]
+          @state_msg = %(Purged Services: '#{@to_purge.join("', '")}')
+        else
+          @state_msg = %(Purged '#{@to_purge.count}' Services)
+        end
+      end
+    end
+
+    return @state_msg
+  end
+
+  def dirs=(target_dirs)
+    # Disable all non-managed services
+    @system_services.select{|s| @to_purge.include?(s.title) }.each do |service|
+
+      service_name = File.basename(service.title, '.service')
+
+      begin
+        Puppet.debug("Stopping Service #{service_name}")
+
+        service.to_ral.provider.send('stop')
+      rescue Puppet::Error
+        # noop
+      end
+
+      begin
+        Puppet.debug("Disabling Service #{service_name}")
+
+        service.to_ral.provider.send('disable')
+      rescue Puppet::Error
+        # noop
+      end
+
+      Array(target_dirs).each do |dir|
+        Dir.glob(File.join(dir, "#{service_name}*")).each do |to_delete|
+          if Puppet::FileSystem.file?(to_delete)
+            Puppet.debug("Purging File '#{to_delete}'")
+
+            Puppet::FileSystem.unlink(to_delete)
+          else
+            Puppet.debug("Refusing to Purge Non-File '#{to_delete}'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/type/stunnel_instance_purge.rb
+++ b/lib/puppet/type/stunnel_instance_purge.rb
@@ -1,0 +1,56 @@
+Puppet::Type.newtype(:stunnel_instance_purge) do
+  desc <<-EOM
+    Disables all services and removes all associated files for
+    ``stunnel::instance`` created resources that are no longer under
+    management.
+
+    This is required so that newly created resources do not have port conflicts
+    upon starting a new service.
+
+    Example:
+
+      stunnel_instance_purge { 'stunnel_managed_by_puppet':
+        dirs => [
+          '/etc/stunnel',
+          '/etc/rc.d/init.d',
+          '/etc/systemd/system'
+        ]
+      }
+
+      This will disable all services that start with ``$namevar`` and will
+      subsequently remove all files in the directories specified in the
+      ``$dirs`` Array that match ``${dir}/${namevar}.*``.
+
+      WARNING: BE VERY CAREFUL THAT ${namevar} IS PRECISE
+  EOM
+
+  newparam(:name, :namevar => true) do
+    desc 'The prefix name of the services to disable and files to remove'
+  end
+
+  newparam(:verbose, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'Provide verbose output in the change message regarding services to be purged'
+  end
+
+  newproperty(:dirs, :array_matching => :all) do
+    desc 'The directories from which the files matching "${name}.*" should be purged'
+
+    # Must be an absolute path
+    newvalues(/^\//)
+
+    def change_to_s(from, to)
+      to_purge = provider.change_to_s
+
+      to_purge
+    end
+  end
+
+  autobefore(:service) do
+    # We find all of the relevant stunnel instances and tack on things that
+    # match 'stunnel' to eliminate all possibility of conflicts on service
+    # restarts
+    catalog.resources.find_all do |r|
+      r.is_a?(Puppet::Type.type(:service)) && (r[:name] =~ /^(stunnel|#{self[:name]})/)
+    end.map(&:title)
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -63,6 +63,12 @@
 # @param setgid
 #   The group stunnel should run as
 #
+# @param uid
+#   The UID of the stunnel user
+#
+# @param gid
+#   The GID of the stunnel user
+#
 # @param stunnel_debug
 #   The debug level for logging
 #
@@ -119,6 +125,8 @@ class stunnel::config (
   Optional[Stdlib::Absolutepath] $pid                     = undef,
   String                         $setuid                  = $::stunnel::setuid,
   String                         $setgid                  = $::stunnel::setgid,
+  Integer                        $uid                     = $::stunnel::uid,
+  Integer                        $gid                     = $::stunnel::gid,
   String                         $stunnel_debug           = 'err',
   Optional[Enum['zlib','rle']]   $compression             = undef,
   Optional[String]               $egd                     = undef,
@@ -132,6 +140,16 @@ class stunnel::config (
   Boolean                        $syslog                  = $::stunnel::syslog,
   Boolean                        $fips                    = $::stunnel::fips
 ) inherits stunnel {
+
+  include '::stunnel::monolithic'
+
+  ensure_resource('stunnel::account', $setuid,
+    {
+      'groupname' => $setgid,
+      'uid'       => $uid,
+      'gid'       => $gid
+    }
+  )
 
   if $facts['selinux_current_mode'] and $facts['selinux_current_mode'] != 'disabled' {
     $_chroot = undef

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,6 +15,8 @@ class stunnel::install (
 ){
   assert_private()
 
+  if $::stunnel::haveged { include '::haveged' }
+
   package { 'stunnel': ensure => $version }
 
   file { '/etc/stunnel':

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -6,8 +6,15 @@
 #    connect => ['1.2.3.4:8730']
 #  }
 #
-# - Creates /etc/stunnel/stunnel_rsync.conf
-# - Spawns service 'stunnel_rsync' from stunnel_rsync.conf
+# * Creates /etc/stunnel/stunnel_managed_by_puppet_rsync.conf
+# * Spawns service 'stunnel_managed_by_puppet_rsync' from the configuration
+#   file
+#
+# Any instances created with this defined type will be removed from the system
+# if no longer managed to prevent conflicts.
+#
+# Instances created with versions of the module prior to 6.3.0 may need to be
+# independently removed since there is no safe way to remove those files.
 #
 # @param name [String]
 #   The name of the stunnel process.
@@ -308,7 +315,7 @@ define stunnel::instance(
     $_pid        = $pid
   } else {
     $_foreground = undef
-    $_pid        = "/var/run/stunnel/stunnel_${_safe_name}.pid"
+    $_pid        = "/var/run/stunnel/stunnel_managed_by_puppet_${_safe_name}.pid"
   }
 
   file { "/etc/stunnel/stunnel_managed_by_puppet_${_safe_name}.conf":

--- a/manifests/instance/reserve_port.pp
+++ b/manifests/instance/reserve_port.pp
@@ -1,0 +1,9 @@
+# **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) DEFINED TYPE**
+#
+# This is a 'canary' defined type that allow us to fail a compile in the case
+# that the `stunnel::interface` and `stunnel::connection` defined types have an
+# overlapping listen port.
+#
+define stunnel::instance::reserve_port {
+  assert_private()
+}

--- a/manifests/monolithic.pp
+++ b/manifests/monolithic.pp
@@ -1,7 +1,7 @@
 # **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 #
-# This is simply present to isolate the logic of the installation from the
-# internals
+# Prevent global connection and configuration from being instantiated when only
+# stunnel::instance resources are required.
 class stunnel::monolithic {
   assert_private()
 

--- a/manifests/monolithic.pp
+++ b/manifests/monolithic.pp
@@ -1,0 +1,18 @@
+# **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
+#
+# This is simply present to isolate the logic of the installation from the
+# internals
+class stunnel::monolithic {
+  assert_private()
+
+  include '::stunnel'
+
+  contain '::stunnel::config'
+  contain '::stunnel::service'
+
+  Class['stunnel::config'] ~> Class['stunnel::service']
+
+  if $::stunnel::haveged {
+    Class['haveged'] ~> Class['stunnel::service']
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.3.1",
+  "version": "6.3.0",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.2.1",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,197 @@
+require 'spec_helper'
+
+describe 'stunnel::config' do
+
+  shared_examples_for "a chrooted and non-chrooted configuration" do
+    # Init
+    it { is_expected.to create_class('stunnel') }
+    it { is_expected.to compile.with_all_deps }
+
+    # User
+    it { is_expected.to create_stunnel__account('stunnel') }
+
+    # Install
+    it { is_expected.to create_class('stunnel::install') }
+    it { is_expected.to create_group('stunnel') }
+    it { is_expected.to create_user('stunnel') }
+    it { is_expected.to create_package('stunnel') }
+
+    # Config
+    it { is_expected.to create_class('stunnel::config') }
+    it { is_expected.to_not contain_class('pki') }
+    it { is_expected.to contain_concat('/etc/stunnel/stunnel.conf') }
+    it { is_expected.to contain_file('/etc/stunnel').with_owner('root') }
+    it { is_expected.to contain_file('/etc/stunnel').with_group('root') }
+    it { is_expected.to contain_file('/etc/stunnel').with_mode('0644') }
+
+    # Service
+    it { is_expected.to create_class('stunnel::service') }
+  end
+
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:facts) {
+          os_facts.merge(
+            selinux_current_mode: 'disabled',
+            selinux_enforced: false
+          )
+        }
+
+        context 'with default parameters (chrooted) and selinux off' do
+          it_should_behave_like "a chrooted and non-chrooted configuration"
+
+          # Specific to chrooting
+          if os_facts[:operatingsystemmajrelease] >= '7'
+            # Fips should be disabled with default params for el 7 systems
+            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
+                chroot = /var/stunnel
+                setgid = stunnel
+                setuid = stunnel
+                debug = err
+                syslog = no
+                foreground = yes
+                pid =
+                engine = auto
+                fips = no
+              EOM
+            )}
+          else
+            # Fips should not exist on an el 6 system
+            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
+                chroot = /var/stunnel
+                setgid = stunnel
+                setuid = stunnel
+                debug = err
+                syslog = no
+                pid = /var/run/stunnel/stunnel.pid
+                engine = auto
+              EOM
+            )}
+          end
+
+          it { is_expected.to contain_file('/var/stunnel') }
+          it { is_expected.to contain_file('/var/stunnel/etc') }
+          it { is_expected.to contain_file('/var/stunnel/etc/resolv.conf') }
+          it { is_expected.to contain_file('/var/stunnel/etc/nsswitch.conf') }
+          it { is_expected.to contain_file('/var/stunnel/etc/hosts') }
+          it { is_expected.to contain_file('/var/stunnel/var') }
+          it { is_expected.to contain_file('/var/stunnel/var/run') }
+          it { is_expected.to contain_file('/var/stunnel/var/run/stunnel') }
+          it { is_expected.to contain_file('/var/stunnel/etc/pki') }
+          it { is_expected.to contain_file('/var/stunnel/etc/pki/cacerts').with_source('file:///etc/pki/simp_apps/stunnel/x509/cacerts') }
+
+          if os_facts[:operatingsystemmajrelease].to_i >= 7
+            let(:service_file) { File.read('spec/expected/connection/chroot-systemd.txt') }
+            it { is_expected.to create_file('/etc/systemd/system/stunnel.service')
+                                  .that_notifies('Exec[stunnel daemon reload]')
+                                  .with_content(service_file) }
+            it { is_expected.to contain_service('stunnel')
+                                  .that_requires('File[/etc/systemd/system/stunnel.service]') }
+            it { is_expected.to contain_exec('stunnel daemon reload') }
+          else
+            let(:service_file) { File.read('spec/expected/connection/chroot-init.txt') }
+            it { is_expected.to create_file('/etc/rc.d/init.d/stunnel').with_content(service_file) }
+            it { is_expected.to contain_service('stunnel').that_requires('File[/etc/rc.d/init.d/stunnel]') }
+          end
+        end
+
+        context 'with selinux = true (non-chrooted)' do
+          let(:facts) {
+            os_facts.merge(
+              selinux_current_mode: 'enforced',
+              selinux_enforced: true
+            )
+          }
+
+          it_should_behave_like "a chrooted and non-chrooted configuration"
+
+          if os_facts[:operatingsystemmajrelease] >= '7'
+            # Fips should be disabled
+            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
+                setgid = stunnel
+                setuid = stunnel
+                debug = err
+                syslog = no
+                foreground = yes
+                pid =
+                engine = auto
+                fips = no
+              EOM
+            )}
+          else
+            # Fips should not exist on an el 6 system
+            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
+                setgid = stunnel
+                setuid = stunnel
+                debug = err
+                syslog = no
+                pid = /var/run/stunnel/stunnel.pid
+                engine = auto
+              EOM
+            )}
+          end
+          it { is_expected.to_not contain_file('/var/stunnel') }
+          it { is_expected.to_not contain_file('/var/stunnel/etc') }
+          it { is_expected.to_not contain_file('/var/stunnel/etc/resolv.conf') }
+          it { is_expected.to_not contain_file('/var/stunnel/etc/nsswitch.conf') }
+          it { is_expected.to_not contain_file('/var/stunnel/etc/hosts') }
+          it { is_expected.to_not contain_file('/var/stunnel/var') }
+          it { is_expected.to_not contain_file('/var/stunnel/var/run') }
+          it { is_expected.to_not contain_file('/var/stunnel/var/run/stunnel') }
+          it { is_expected.to_not contain_file('/var/stunnel/etc/pki') }
+          it { is_expected.to_not contain_file('/var/stunnel/etc/pki/cacerts').with_source('file:///etc/pki/simp_apps/stunnel/x509/cacerts') }
+
+          if os_facts[:operatingsystemmajrelease].to_i >= 7
+            let(:service_file) { File.read('spec/expected/connection/nonchroot-systemd.txt') }
+            it { is_expected.to create_file('/etc/systemd/system/stunnel.service')
+                                   .that_notifies('Exec[stunnel daemon reload]')
+                                   .with_content(service_file) }
+            it { is_expected.to contain_service('stunnel')
+                                  .that_requires('File[/etc/systemd/system/stunnel.service]') }
+            it { is_expected.to contain_exec('stunnel daemon reload') }
+          else
+            let(:service_file) { File.read('spec/expected/connection/nonchroot-init.txt') }
+            it { is_expected.to create_file('/etc/rc.d/init.d/stunnel').with_content(service_file) }
+            it { is_expected.to contain_service('stunnel').that_requires('File[/etc/rc.d/init.d/stunnel]') }
+          end
+        end
+        context 'with pki = simp, syslog = true, and fips = true' do
+          let(:params) {{
+            pki:     'simp',
+            syslog:  true,
+            fips:    true
+          }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('pki') }
+          it { is_expected.to create_pki__copy('stunnel') }
+          # Make sure syslog = yes in stunnel.conf
+          it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(/syslog = yes/) }
+          # Fips should be enabled on el 7 systems
+          if os_facts[:operatingsystemmajrelease] >= '7'
+            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(/fips = yes/) }
+          # Fips should not exist on an el 6 system
+          else
+            it { is_expected.to contain_concat__fragment('0_stunnel_global').without_content(/fips/) }
+          end
+        end
+
+        context 'with pid specified' do
+          # I have to go to hiera for this...
+          # stunnel::config::pid: /var/opt/run/stunnel.pid
+          let(:hieradata) { 'pid' }
+          it { is_expected.to compile.with_all_deps }
+          if os_facts[:operatingsystemmajrelease].to_i >= 7
+            let(:service_file) { File.read('spec/expected/connection/chroot-systemd-pid.txt') }
+            it { is_expected.to contain_file('/etc/systemd/system/stunnel.service')
+                                  .with_content(service_file) }
+          else
+            let(:service_file) { File.read('spec/expected/connection/chroot-init-pid.txt') }
+            it { is_expected.to contain_file('/etc/rc.d/init.d/stunnel')
+                                  .with_content(service_file) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,197 +1,36 @@
 require 'spec_helper'
 
 describe 'stunnel' do
-
-  shared_examples_for "a chrooted and non-chrooted configuration" do
-    # Init
-    it { is_expected.to create_class('stunnel') }
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to_not contain_class('haveged') }
-
-    # User
-    it { is_expected.to create_stunnel__account('stunnel').that_comes_before('Class[stunnel::config]') }
-
-    # Install
-    it { is_expected.to create_class('stunnel::install').that_comes_before('Stunnel::Account[stunnel]') }
-    it { is_expected.to create_group('stunnel') }
-    it { is_expected.to create_user('stunnel') }
-    it { is_expected.to create_package('stunnel') }
-
-    # Config
-    it { is_expected.to create_class('stunnel::config') }
-    it { is_expected.to_not contain_class('pki') }
-    it { is_expected.to contain_concat('/etc/stunnel/stunnel.conf') }
-    it { is_expected.to contain_file('/etc/stunnel').with_owner('root') }
-    it { is_expected.to contain_file('/etc/stunnel').with_group('root') }
-    it { is_expected.to contain_file('/etc/stunnel').with_mode('0644') }
-
-    # Service
-    it { is_expected.to create_class('stunnel::service') }
-  end
-
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) {
-          os_facts.merge(
-            selinux_current_mode: 'disabled',
-            selinux_enforced: false
-          )
+        let(:facts){ os_facts }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('stunnel') }
+        it { is_expected.to_not create_class('haveged') }
+        it { is_expected.to create_class('stunnel::install') }
+        it { is_expected.to create_package('stunnel').with_ensure('installed') }
+        it { is_expected.to create_file('/etc/stunnel').with({
+            :ensure => 'directory',
+            :owner  => 'root',
+            :group  => 'root',
+            :mode   => '0644'
+          }).that_requires('Package[stunnel]')
+        }
+        it { is_expected.to create_stunnel_instance_purge('stunnel_managed_by_puppet').with_dirs([
+            '/etc/stunnel',
+            '/etc/rc.d/init.d',
+            '/etc/systemd/system'
+          ])
         }
 
-        context 'with default parameters (chrooted) and selinux off' do
-          it_should_behave_like "a chrooted and non-chrooted configuration"
-
-          # Specific to chrooting
-          if os_facts[:operatingsystemmajrelease] >= '7'
-            # Fips should be disabled with default params for el 7 systems
-            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
-                chroot = /var/stunnel
-                setgid = stunnel
-                setuid = stunnel
-                debug = err
-                syslog = no
-                foreground = yes
-                pid =
-                engine = auto
-                fips = no
-              EOM
-            )}
-          else
-            # Fips should not exist on an el 6 system
-            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
-                chroot = /var/stunnel
-                setgid = stunnel
-                setuid = stunnel
-                debug = err
-                syslog = no
-                pid = /var/run/stunnel/stunnel.pid
-                engine = auto
-              EOM
-            )}
-          end
-
-          it { is_expected.to contain_file('/var/stunnel') }
-          it { is_expected.to contain_file('/var/stunnel/etc') }
-          it { is_expected.to contain_file('/var/stunnel/etc/resolv.conf') }
-          it { is_expected.to contain_file('/var/stunnel/etc/nsswitch.conf') }
-          it { is_expected.to contain_file('/var/stunnel/etc/hosts') }
-          it { is_expected.to contain_file('/var/stunnel/var') }
-          it { is_expected.to contain_file('/var/stunnel/var/run') }
-          it { is_expected.to contain_file('/var/stunnel/var/run/stunnel') }
-          it { is_expected.to contain_file('/var/stunnel/etc/pki') }
-          it { is_expected.to contain_file('/var/stunnel/etc/pki/cacerts').with_source('file:///etc/pki/simp_apps/stunnel/x509/cacerts') }
-
-          if os_facts[:operatingsystemmajrelease].to_i >= 7
-            let(:service_file) { File.read('spec/expected/connection/chroot-systemd.txt') }
-            it { is_expected.to create_file('/etc/systemd/system/stunnel.service')
-                                  .that_notifies('Exec[stunnel daemon reload]')
-                                  .with_content(service_file) }
-            it { is_expected.to contain_service('stunnel')
-                                  .that_requires('File[/etc/systemd/system/stunnel.service]') }
-            it { is_expected.to contain_exec('stunnel daemon reload') }
-          else
-            let(:service_file) { File.read('spec/expected/connection/chroot-init.txt') }
-            it { is_expected.to create_file('/etc/rc.d/init.d/stunnel').with_content(service_file) }
-            it { is_expected.to contain_service('stunnel').that_requires('File[/etc/rc.d/init.d/stunnel]') }
-          end
-        end
-
-        context 'with selinux = true (non-chrooted)' do
-          let(:facts) {
-            os_facts.merge(
-              selinux_current_mode: 'enforced',
-              selinux_enforced: true
-            )
-          }
-
-          it_should_behave_like "a chrooted and non-chrooted configuration"
-
-          if os_facts[:operatingsystemmajrelease] >= '7'
-            # Fips should be disabled
-            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
-                setgid = stunnel
-                setuid = stunnel
-                debug = err
-                syslog = no
-                foreground = yes
-                pid =
-                engine = auto
-                fips = no
-              EOM
-            )}
-          else
-            # Fips should not exist on an el 6 system
-            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(<<-EOM.gsub(/^\s+/,'')
-                setgid = stunnel
-                setuid = stunnel
-                debug = err
-                syslog = no
-                pid = /var/run/stunnel/stunnel.pid
-                engine = auto
-              EOM
-            )}
-          end
-          it { is_expected.to_not contain_file('/var/stunnel') }
-          it { is_expected.to_not contain_file('/var/stunnel/etc') }
-          it { is_expected.to_not contain_file('/var/stunnel/etc/resolv.conf') }
-          it { is_expected.to_not contain_file('/var/stunnel/etc/nsswitch.conf') }
-          it { is_expected.to_not contain_file('/var/stunnel/etc/hosts') }
-          it { is_expected.to_not contain_file('/var/stunnel/var') }
-          it { is_expected.to_not contain_file('/var/stunnel/var/run') }
-          it { is_expected.to_not contain_file('/var/stunnel/var/run/stunnel') }
-          it { is_expected.to_not contain_file('/var/stunnel/etc/pki') }
-          it { is_expected.to_not contain_file('/var/stunnel/etc/pki/cacerts').with_source('file:///etc/pki/simp_apps/stunnel/x509/cacerts') }
-
-          if os_facts[:operatingsystemmajrelease].to_i >= 7
-            let(:service_file) { File.read('spec/expected/connection/nonchroot-systemd.txt') }
-            it { is_expected.to create_file('/etc/systemd/system/stunnel.service')
-                                   .that_notifies('Exec[stunnel daemon reload]')
-                                   .with_content(service_file) }
-            it { is_expected.to contain_service('stunnel')
-                                  .that_requires('File[/etc/systemd/system/stunnel.service]') }
-            it { is_expected.to contain_exec('stunnel daemon reload') }
-          else
-            let(:service_file) { File.read('spec/expected/connection/nonchroot-init.txt') }
-            it { is_expected.to create_file('/etc/rc.d/init.d/stunnel').with_content(service_file) }
-            it { is_expected.to contain_service('stunnel').that_requires('File[/etc/rc.d/init.d/stunnel]') }
-          end
-        end
-        context 'with pki = simp, haveged = true, syslog = true, and fips = true' do
-          let(:params) {{
-            pki:     'simp',
-            haveged: true,
-            syslog:  true,
-            fips:    true
+        context 'with haveged included' do
+          let(:params){{
+            :haveged => true
           }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('pki') }
-          it { is_expected.to create_pki__copy('stunnel') }
-          # Make sure syslog = yes in stunnel.conf
-          it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(/syslog = yes/) }
-          # Fips should be enabled on el 7 systems
-          if os_facts[:operatingsystemmajrelease] >= '7'
-            it { is_expected.to contain_concat__fragment('0_stunnel_global').with_content(/fips = yes/) }
-          # Fips should not exist on an el 6 system
-          else
-            it { is_expected.to contain_concat__fragment('0_stunnel_global').without_content(/fips/) }
-          end
-        end
 
-        context 'with pid specified' do
-          # I have to go to hiera for this...
-          # stunnel::config::pid: /var/opt/run/stunnel.pid
-          let(:hieradata) { 'pid' }
-          it { is_expected.to compile.with_all_deps }
-          if os_facts[:operatingsystemmajrelease].to_i >= 7
-            let(:service_file) { File.read('spec/expected/connection/chroot-systemd-pid.txt') }
-            it { is_expected.to contain_file('/etc/systemd/system/stunnel.service')
-                                  .with_content(service_file) }
-          else
-            let(:service_file) { File.read('spec/expected/connection/chroot-init-pid.txt') }
-            it { is_expected.to contain_file('/etc/rc.d/init.d/stunnel')
-                                  .with_content(service_file) }
-          end
+          it { is_expected.to create_class('haveged') }
         end
       end
     end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -31,7 +31,7 @@ setgid = stunnel
 setuid = stunnel
 debug = err
 syslog = no
-pid = /var/run/stunnel/stunnel_nfs.pid
+pid = /var/run/stunnel/stunnel_managed_by_puppet_nfs.pid
 engine = auto
 [nfs]
 connect = 2049

--- a/spec/expected/connection/chroot-systemd-pid.txt
+++ b/spec/expected/connection/chroot-systemd-pid.txt
@@ -3,6 +3,7 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel listener
+Wants=network-online.target
 
 [Service]
 Type=simple
@@ -11,3 +12,7 @@ ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/expected/connection/chroot-systemd.txt
+++ b/spec/expected/connection/chroot-systemd.txt
@@ -3,6 +3,7 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel listener
+Wants=network-online.target
 
 [Service]
 Type=simple
@@ -11,3 +12,7 @@ ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/expected/connection/nonchroot-systemd.txt
+++ b/spec/expected/connection/nonchroot-systemd.txt
@@ -3,6 +3,7 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel listener
+Wants=network-online.target
 
 [Service]
 Type=simple
@@ -11,3 +12,7 @@ ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/expected/instance/chroot-init.txt
+++ b/spec/expected/instance/chroot-init.txt
@@ -24,7 +24,7 @@ ulimit -u unlimited
 
 conf=/etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 
-pidfile="/var/stunnel_nfs/var/run/stunnel/stunnel_nfs.pid";
+pidfile="/var/stunnel_nfs/var/run/stunnel/stunnel_managed_by_puppet_nfs.pid";
 piddir=`dirname "${pidfile}"`
 
 # If the command doesn't exist, that's probably not going to work

--- a/spec/expected/instance/chroot-init.txt
+++ b/spec/expected/instance/chroot-init.txt
@@ -22,7 +22,7 @@ ulimit -u unlimited
 # Account for the various locations in different OSs
 [ -f /usr/sbin/stunnel ] && exec=/usr/sbin/stunnel || exec=/usr/bin/stunnel
 
-conf=/etc/stunnel/stunnel_nfs.conf
+conf=/etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 
 pidfile="/var/stunnel_nfs/var/run/stunnel/stunnel_nfs.pid";
 piddir=`dirname "${pidfile}"`

--- a/spec/expected/instance/chroot-sel-init.txt
+++ b/spec/expected/instance/chroot-sel-init.txt
@@ -24,7 +24,7 @@ ulimit -u unlimited
 
 conf=/etc/stunnel/stunnel_managed_by_puppet_sel.conf
 
-pidfile="/var/stunnel_sel/var/run/stunnel/stunnel_sel.pid";
+pidfile="/var/stunnel_sel/var/run/stunnel/stunnel_managed_by_puppet_sel.pid";
 piddir=`dirname "${pidfile}"`
 
 # If the command doesn't exist, that's probably not going to work

--- a/spec/expected/instance/chroot-sel-init.txt
+++ b/spec/expected/instance/chroot-sel-init.txt
@@ -22,7 +22,7 @@ ulimit -u unlimited
 # Account for the various locations in different OSs
 [ -f /usr/sbin/stunnel ] && exec=/usr/sbin/stunnel || exec=/usr/bin/stunnel
 
-conf=/etc/stunnel/stunnel_sel.conf
+conf=/etc/stunnel/stunnel_managed_by_puppet_sel.conf
 
 pidfile="/var/stunnel_sel/var/run/stunnel/stunnel_sel.pid";
 piddir=`dirname "${pidfile}"`

--- a/spec/expected/instance/chroot-sel-systemd.txt
+++ b/spec/expected/instance/chroot-sel-systemd.txt
@@ -3,10 +3,15 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel_sel listener
+Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_sel.conf
+ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_sel.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/expected/instance/chroot-systemd.txt
+++ b/spec/expected/instance/chroot-systemd.txt
@@ -3,10 +3,15 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel_nfs listener
+Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_nfs.conf
+ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/expected/instance/nonchroot-init.txt
+++ b/spec/expected/instance/nonchroot-init.txt
@@ -24,7 +24,7 @@ ulimit -u unlimited
 
 conf=/etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 
-pidfile="/var/run/stunnel/stunnel_nfs.pid";
+pidfile="/var/run/stunnel/stunnel_managed_by_puppet_nfs.pid";
 piddir=`dirname "${pidfile}"`
 
 # If the command doesn't exist, that's probably not going to work

--- a/spec/expected/instance/nonchroot-init.txt
+++ b/spec/expected/instance/nonchroot-init.txt
@@ -22,7 +22,7 @@ ulimit -u unlimited
 # Account for the various locations in different OSs
 [ -f /usr/sbin/stunnel ] && exec=/usr/sbin/stunnel || exec=/usr/bin/stunnel
 
-conf=/etc/stunnel/stunnel_nfs.conf
+conf=/etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 
 pidfile="/var/run/stunnel/stunnel_nfs.pid";
 piddir=`dirname "${pidfile}"`

--- a/spec/expected/instance/nonchroot-systemd.txt
+++ b/spec/expected/instance/nonchroot-systemd.txt
@@ -3,10 +3,15 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel_nfs listener
+Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_nfs.conf
+ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/unit/puppet/provider/stunnel_instance_purge/purge_spec.rb
+++ b/spec/unit/puppet/provider/stunnel_instance_purge/purge_spec.rb
@@ -1,0 +1,65 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:stunnel_instance_purge).provider(:purge)
+
+describe provider_class do
+  let :verbose do
+    false
+  end
+
+  let :resource do
+    Puppet::Type::Stunnel_instance_purge.new(
+      {
+        :name    => 'test',
+        :dirs    => ['/foo'],
+        :verbose => verbose
+      }
+    )
+  end
+
+  let :provider do
+    # Don't hit the local system
+    Puppet::Resource::indirection.stubs(:search).with('Service', {}).returns([])
+
+    provider_class.new(resource)
+  end
+
+  describe '#dirs' do
+    before(:each) do
+      @catalog = Puppet::Resource::Catalog.new('Stunnel Test', 'production')
+      @catalog.add_resource(resource)
+    end
+
+    it 'does not have any changes' do
+      # No changes should be expected here so we return what we were passed
+      expect(provider.dirs).to eq(resource[:dirs])
+    end
+
+    context 'with additional services' do
+      let :provider do
+        # Don't hit the local system
+        Puppet::Resource::indirection.stubs(:search).with('Service', {}).returns([
+          Puppet::Resource.new(:service, 'test_should_be_purged'),
+          Puppet::Resource.new(:service, 'should_not_be_purged')
+        ])
+
+        provider_class.new(resource)
+      end
+
+      it 'should purge rogue services' do
+        expect(provider.dirs).to eq(%(Purged '1' Services))
+      end
+
+      context 'when verbose' do
+        let :verbose do
+          true
+        end
+
+        it 'should purge rogue services and dislay their names' do
+          expect(provider.dirs).to eq(%(Purged Services: 'test_should_be_purged'))
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/stunnel_instance_purge_spec.rb
+++ b/spec/unit/puppet/type/stunnel_instance_purge_spec.rb
@@ -1,0 +1,44 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Type.type(:stunnel_instance_purge) do
+  let :stunnel_instance_purge do
+    Puppet::Type.type(:stunnel_instance_purge).new(:name => 'test', :verbose => false, :dirs => ['/test'])
+  end
+
+  it 'should accept a verbose flag' do
+    stunnel_instance_purge[:verbose] = true
+    expect(stunnel_instance_purge[:verbose]).to eq(true)
+  end
+
+  it 'should accept an Array of target directories' do
+    stunnel_instance_purge[:dirs] = ['/foo', '/bar']
+    expect(stunnel_instance_purge[:dirs]).to eq(['/foo', '/bar'])
+  end
+
+  it 'should accept an absolute path for all :dirs entries' do
+    expect {
+      Puppet::Type.type(:stunnel_instance_purge).new(
+        :name => 'test',
+        :dirs => [
+          '/foo',
+          '/bar',
+          '/foo/bar/baz/stuff'
+        ]
+      )
+    }.not_to raise_error
+  end
+
+  it 'should not accept non-absolute paths for any :dirs entries' do
+    expect {
+      Puppet::Type.type(:stunnel_instance_purge).new(
+        :name => 'test',
+        :dirs => [
+          '/foo',
+          '/bar',
+          'foo/bar/baz/stuff'
+        ]
+      )
+    }.to raise_error(/Invalid value.*"foo/)
+  end
+end

--- a/templates/connection_systemd.erb
+++ b/templates/connection_systemd.erb
@@ -3,6 +3,7 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel listener
+Wants=network-online.target
 
 [Service]
 Type=simple
@@ -15,3 +16,7 @@ ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/instance_init.erb
+++ b/templates/instance_init.erb
@@ -22,7 +22,7 @@ ulimit -u unlimited
 # Account for the various locations in different OSs
 [ -f /usr/sbin/stunnel ] && exec=/usr/sbin/stunnel || exec=/usr/bin/stunnel
 
-conf=/etc/stunnel/stunnel_<%= @_safe_name %>.conf
+conf=/etc/stunnel/stunnel_managed_by_puppet_<%= @_safe_name %>.conf
 
 <% if @_chroot.to_s.length > 0 -%>
 pidfile="<%= "#{@_chroot}#{@_pid}" %>";

--- a/templates/instance_systemd.erb
+++ b/templates/instance_systemd.erb
@@ -3,10 +3,15 @@
 # ####################################################################
 [Unit]
 Description=Start a stunnel_<%= @_safe_name %> listener
+Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_<%= @_safe_name %>.conf
+ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_<%= @_safe_name %>.conf
 KillMode=process
 LimitNOFILE=1048576
 LimitNPROC=infinity
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* Isolated the 'instance' logic away from the 'connection' logic
* Added a private 'monolithic' class that arranges everything properly
  for the legacy stunnel connections
* Ensure that 'instances' and 'connections' do not conflict by using a
  'reserve_port' class
* Add a native type that will clean up all instances that would be
  randomly created by the 'stunnel::instance' defines and will come
  before both legacy and new stunnel connections so that we do not have
  random left over services that may conflict with new services

SIMP-4016 #comment Stunnel Instance Safety Updates
SIMP-4102 #comment Required Stunnel Updates for TCP_NODELAY capabilities