### PR TITLE
(SIMP-4477) Add fully qualified paths to startup scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
 
   include:
-    - stage: spec
+    - stage: check
       rvm: 2.4.1
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Mar 06 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.0
+- Fixed bug in which the stunnel systemd pre-exec script failed to
+  execute completely, because one command did not have a fully
+  qualified path.
+- Reworked stunnel systemd pre-exec scripts to only emit error
+  messages when errors have occurred.
+
 * Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0
 - Isolated the 'instance' logic away from the 'connection' logic
 - Added a private 'monolithic' class that arranges everything properly for the

--- a/spec/acceptance/suites/default/00_instances_spec.rb
+++ b/spec/acceptance/suites/default/00_instances_spec.rb
@@ -139,11 +139,6 @@ describe 'instance' do
         ].each do |service|
           on(host, "puppet resource service #{service} ensure=stopped enable=false")
         end
-
-        # There was an issue where the domain fact would cease to exist, causing failures
-        on(host, 'service network restart')
-        # Get rid of stunnels
-        # on(host, "ps aux | grep -ie stunnel | grep -v 'grep' | awk '{print $2}' | xargs --no-run-if-empty kill -9")
       end
     end
   end

--- a/spec/expected/connection/chroot-systemd-pid.txt
+++ b/spec/expected/connection/chroot-systemd-pid.txt
@@ -7,7 +7,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/stunnel/var/opt/run/stunnel.pid ; rm /var/stunnel/var/opt/run/stunnel.pid
+ExecStartPre=/bin/bash -c 'if test -f /var/stunnel/var/opt/run/stunnel.pid; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/stunnel/var/opt/run/stunnel.pid; fi'
+ExecStartPre=/usr/bin/rm -f /var/stunnel/var/opt/run/stunnel.pid
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576

--- a/spec/expected/connection/chroot-systemd.txt
+++ b/spec/expected/connection/chroot-systemd.txt
@@ -7,7 +7,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/stunnel/var/run/stunnel/stunnel.pid ; rm /var/stunnel/var/run/stunnel/stunnel.pid
+ExecStartPre=/bin/bash -c 'if test -f /var/stunnel/var/run/stunnel/stunnel.pid; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/stunnel/var/run/stunnel/stunnel.pid; fi'
+ExecStartPre=/usr/bin/rm -f /var/stunnel/var/run/stunnel/stunnel.pid
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576

--- a/spec/expected/connection/nonchroot-systemd.txt
+++ b/spec/expected/connection/nonchroot-systemd.txt
@@ -7,7 +7,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/run/stunnel/stunnel.pid ; rm /var/run/stunnel/stunnel.pid
+ExecStartPre=/bin/bash -c 'if test -f /var/run/stunnel/stunnel.pid; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/run/stunnel/stunnel.pid; fi'
+ExecStartPre=/usr/bin/rm -f /var/run/stunnel/stunnel.pid
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
 LimitNOFILE=1048576

--- a/templates/connection_systemd.erb
+++ b/templates/connection_systemd.erb
@@ -8,9 +8,11 @@ Wants=network-online.target
 [Service]
 Type=simple
 <% if @_chroot -%>
-ExecStartPre=-/usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F <%= @_chroot %><%= @_legacy_pid %> ; rm <%= @_chroot %><%= @_legacy_pid %>
+ExecStartPre=/bin/bash -c 'if test -f <%= @_chroot %><%= @_legacy_pid %>; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F <%= @_chroot %><%= @_legacy_pid %>; fi'
+ExecStartPre=/usr/bin/rm -f <%= @_chroot %><%= @_legacy_pid %>
 <% else -%>
-ExecStartPre=-/usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F <%= @_legacy_pid %> ; rm <%= @_chroot %><%= @_legacy_pid %>
+ExecStartPre=/bin/bash -c 'if test -f <%= @_legacy_pid %>; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F <%= @_legacy_pid %>; fi'
+ExecStartPre=/usr/bin/rm -f <%= @_legacy_pid %>
 <% end -%>
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process


### PR DESCRIPTION
- Fixed bug in which the stunnel systemd pre-exec script failed to
  execute completely, because one command did not have a fully
  qualified path.
- Reworked stunnel systemd pre-exec scripts to only emit error
  messages when errors have occurred.
- Tweaked workaround for munged /etc/resolv.conf problem in
  acceptance test.

SIMP-4477 #close