### PR TITLE
(SIMP-4568) Stunnel changing ownership of root

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Mar 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0
+- Ensure init.d script is absent if systemd system because puppet
+  was finding it and running it and setting permissions on root to
+  stunnel:stunnel.
+- Ensure pid file name is not left undefined to prevent unplanned results.
+- Added check to make sure chroot has not evaluated to '/'.
+
 * Tue Mar 06 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.0
 - Fixed bug in which the stunnel systemd pre-exec script failed to
   execute completely, because one command did not have a fully

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -171,15 +171,30 @@ class stunnel::config (
   if $pid =~ Undef {
     if $on_systemd {
       $_foreground = true
-      $_pid        = '/var/run/stunnel/stunnel.pid'
     } else {
       $_foreground = undef
-      $_pid        = '/var/run/stunnel/stunnel.pid'
     }
+    $_pid        = '/var/run/stunnel/stunnel.pid'
     $_legacy_pid = '/var/run/stunnel/stunnel.pid'
+
   } else {
     $_pid        = $pid
     $_legacy_pid = $pid
+  }
+
+  if $_pid {
+    $_stunnel_piddir = File[dirname($_pid)]
+    ensure_resource('file', dirname($_pid),
+      {
+        'ensure'  => 'directory',
+        'owner'   => $setuid,
+        'group'   => $setgid,
+        'mode'    => '0644',
+        'seluser' => 'system_u',
+        'selrole' => 'object_r',
+        'seltype' => 'stunnel_var_run_t',
+      }
+    )
   }
 
   concat { '/etc/stunnel/stunnel.conf':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -171,7 +171,7 @@ class stunnel::config (
   if $pid =~ Undef {
     if $on_systemd {
       $_foreground = true
-      $_pid        = $pid
+      $_pid        = '/var/run/stunnel/stunnel.pid'
     } else {
       $_foreground = undef
       $_pid        = '/var/run/stunnel/stunnel.pid'
@@ -196,7 +196,12 @@ class stunnel::config (
     content => template('stunnel/connection_conf.erb')
   }
 
-  if $_chroot {
+  if $_chroot !~ Undef {
+    # $chroot should never be undef here, or just '/'.
+    if $_chroot in ['/',''] {
+      fail("stunnel: \$chroot should not be root ('/')")
+    }
+
     # The _chroot directory
     file { $_chroot:
       ensure => 'directory',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,17 +5,22 @@
 class stunnel::service {
 
   if 'systemd' in $facts['init_systems'] {
+    file { '/etc/rc.d/init.d/stunnel': ensure => 'absent' }
+
     service { 'stunnel':
       ensure  => running,
       enable  => true,
-      require => File['/etc/systemd/system/stunnel.service']
+      require => [
+        File['/etc/systemd/system/stunnel.service'],
+        File['/etc/rc.d/init.d/stunnel']
+      ]
     }
   } else {
     # The script takes care of chkconfig
     service { 'stunnel':
       ensure  => running,
       enable  => true,
-      require => File['/etc/rc.d/init.d/stunnel'],
+      require => File['/etc/rc.d/init.d/stunnel']
     }
   }
 }

--- a/spec/acceptance/suites/default/00_instances_spec.rb
+++ b/spec/acceptance/suites/default/00_instances_spec.rb
@@ -43,8 +43,6 @@ describe 'instance' do
       it 'should apply with no errors' do
         set_hieradata_on(host,hieradata)
         apply_manifest_on(host,manifest)
-        apply_manifest_on(host,manifest, catch_failures: true)
-        apply_manifest_on(host,manifest, catch_failures: true)
       end
 
       it 'should be idempotent' do

--- a/spec/acceptance/suites/default/01_connection_spec.rb
+++ b/spec/acceptance/suites/default/01_connection_spec.rb
@@ -60,14 +60,13 @@ describe 'connection' do
           on(host, 'chown -R root:root /etc/pki/simp-testing/pki')
           on(host, 'chmod -R go+r /etc/pki/simp-testing/pki')
           on(host, 'chcon -R --type cert_t /etc/pki/simp-testing/pki')
-          on(host, '/etc/rc.d/init.d/stunnel_legacy start')
+          on(host, 'SYSTEMCTL_SKIP_REDIRECT=yes /etc/rc.d/init.d/stunnel_legacy start')
           pid = on(host, 'cat /var/run/stunnel/stunnel.pid').stdout.strip
           on(host, "ps -f --pid #{pid}")
 
           apply_manifest_on(host,base_manifest, catch_failures: true)
           apply_manifest_on(host,base_manifest, catch_changes: true)
           on(host, "ps -f --pid #{pid}", :acceptable_exit_codes => [1])
-          on(host, 'ls /var/run/stunnel/stunnel.pid', :acceptable_exit_codes => [2])
         end
       end
     end


### PR DESCRIPTION
- Removed init.d script on systemd systems.
- Added checks for chroot evaluation to '/'
- Set value for pidfile name if it was undefined to
  prevent problems if for some reason the old init.d
  script is on the system.

SIMP-4568 #comment close