### PR TITLE
(SIMP-4598) Fix NFS over stunnel for systemd at startup and shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Mar 30 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.1
+- Fix bug in which stunnel.service does not startup and shutdown
+  properly for NFS.  Patch provided by Mark Fitch in SIMP-4598.
+
 * Tue Mar 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0
 - Ensure init.d script is absent if systemd system because puppet
   was finding it and running it and setting permissions on root to

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",

--- a/spec/expected/connection/chroot-systemd-pid.txt
+++ b/spec/expected/connection/chroot-systemd-pid.txt
@@ -17,3 +17,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/spec/expected/connection/chroot-systemd.txt
+++ b/spec/expected/connection/chroot-systemd.txt
@@ -17,3 +17,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/spec/expected/connection/nonchroot-systemd.txt
+++ b/spec/expected/connection/nonchroot-systemd.txt
@@ -17,3 +17,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/spec/expected/instance/chroot-sel-systemd.txt
+++ b/spec/expected/instance/chroot-sel-systemd.txt
@@ -15,3 +15,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/spec/expected/instance/chroot-systemd.txt
+++ b/spec/expected/instance/chroot-systemd.txt
@@ -15,3 +15,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/spec/expected/instance/nonchroot-systemd.txt
+++ b/spec/expected/instance/nonchroot-systemd.txt
@@ -15,3 +15,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/templates/connection_systemd.erb
+++ b/templates/connection_systemd.erb
@@ -22,3 +22,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target

--- a/templates/instance_systemd.erb
+++ b/templates/instance_systemd.erb
@@ -15,3 +15,4 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=remote-fs.target


### PR DESCRIPTION
Fix bug in which stunnel.service does not startup and shutdown
properly for NFS.  Patch provided by Mark Fitch in SIMP-4598.

SIMP-4598 #close