### PR TITLE
(SIMP-4636) Add systemd triggers to stunnel::instance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,20 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+#
+# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  2018-10  (LTS)
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.2   4.10  2.1.9  2018-02-21
+# PE 2017.3   5.3   2.4.1  2018-07
+# PE 2018.1   ???   ?????  ????-??  (LTS)
 ---
 .cache_bundler: &cache_bundler
   cache:
     untracked: true
-    # An attempt at caching between runs (ala Travis CI)
+    # A broad attempt at caching between runs (ala Travis CI)
     key: "${CI_PROJECT_NAMESPACE}__bundler"
     paths:
       - '.vendor'
@@ -10,61 +22,168 @@
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    - '(find .vendor | wc -l) || :'
-    - bundle || gem install bundler --no-rdoc --no-ri
-    - rm -rf Gemfile.lock pkg/
-    - bundle install --no-binstubs --jobs $(nproc) --path .vendor "${FLAGS[@]}"
+    - 'echo Files in cache: $(find .vendor | wc -l) || :'
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
 
-.static_tests: &static_tests
+
+.validation_checks: &validation_checks
   script:
     - bundle exec rake syntax
-    - bundle exec rake lint
     - bundle exec rake check:dot_underscore
     - bundle exec rake check:test_file
     - bundle exec rake pkg:check_version
     - bundle exec rake pkg:compare_latest_tag
-    - bundle exec rake spec
+    - bundle exec rake lint
+    - bundle exec rake clean
     - bundle exec puppet module build
 
+.spec_tests: &spec_tests
+  script:
+    - bundle exec rake spec
+
 stages:
+  - validation
   - unit
   - acceptance
   - deploy
 
-# Puppet 4
-puppet-gemfile:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.1.9
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *static_tests
-
-# For PE LTS Support
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet-4.7:
+# --------------------------------------
+pup4_7-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_7-unit:
   stage: unit
   tags:
     - docker
-  image: ruby:2.1.9
+  image: ruby:2.1
   variables:
-    PUPPET_VERSION: '4.7'
+    PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *static_tests
+  <<: *spec_tests
 
-puppet-5:
+
+# Puppet 4.8 for SIMP 6.0 + 6.1 support
+# --------------------------------------
+pup4_8-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_8-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4_10-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_10-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5_3-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup5_3-unit:
   stage: unit
   tags:
     - docker
   image: ruby:2.4
   variables:
-    PUPPET_VERSION: '5.0'
+    PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *static_tests
+  <<: *spec_tests
   allow_failure: true
+
+
+# Keep an eye on the latest puppet 5
+# ----------------------------------
+pup5_latest-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5_latest-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
 
 default:
   stage: acceptance
@@ -88,15 +207,3 @@ default-fips:
     PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[default]
-
-default-latest:
-  stage: acceptance
-  tags:
-    - beaker
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '5.0.0'
-  script:
-    - bundle exec rake beaker:suites[default]
-  allow_failure: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 # ------------------------------------------------------------------------------
 #  release    pup   ruby      eol
 # PE 2016.4   4.7   2.1.9  TBD (LTS)
@@ -13,6 +12,7 @@ sudo: false
 
 bundler_args: --without development system_tests --path .vendor
 
+
 notifications:
   email: false
 
@@ -26,7 +26,6 @@ before_install:
 
 jobs:
   allow_failures:
-    # https://tickets.puppetlabs.com/browse/PUP-8418
     - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
 
   include:
@@ -67,7 +66,7 @@ jobs:
       script:
         - bundle exec rake spec
 
-    # This needs to be last since we have an acceptance test
+
     - stage: deploy
       rvm: 2.4.1
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
   - systemd_requiredby: sent to the RequiredBy systemd unit install directive
   - These should allow ordering during boot. For example, if you have NFS set up
     over stunnel, you want stunnel to start before NFS.
+- Fixed the systemd startup scripts to properly pre-create the PID directory if
+  required
 
 * Tue Mar 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0
 - Ensure init.d script is absent if systemd system because puppet

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Apr 03 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.3.1
+- Added two new parameters to the stunnel::instance define:
+  - systemd_wantedby: sent to the WantedBy systemd unit install directive
+  - systemd_requiredby: sent to the RequiredBy systemd unit install directive
+  - These should allow ordering during boot. For example, if you have NFS set up
+    over stunnel, you want stunnel to start before NFS.
+
 * Tue Mar 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.0
 - Ensure init.d script is absent if systemd system because puppet
   was finding it and running it and setting permissions on root to

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -168,6 +168,7 @@ class stunnel::config (
   # $_legacy_pid is used to kill the old stunnel process set up from a previous
   #   version of this module. It should be set to $_pid, unless $_pid is unset.
   $on_systemd = 'systemd' in $facts['init_systems']
+
   if $pid =~ Undef {
     if $on_systemd {
       $_foreground = true
@@ -182,7 +183,7 @@ class stunnel::config (
     $_legacy_pid = $pid
   }
 
-  if $_pid {
+  if $_pid and !$on_systemd {
     $_stunnel_piddir = File[dirname($_pid)]
     ensure_resource('file', dirname($_pid),
       {
@@ -212,9 +213,11 @@ class stunnel::config (
   }
 
   if $_chroot !~ Undef {
-    # $chroot should never be undef here, or just '/'.
     if $_chroot in ['/',''] {
       fail("stunnel: \$chroot should not be root ('/')")
+    }
+    if $_chroot =~ /^\/var\/run/ {
+      fail("stunnel: \$chroot cannot be under /var/run")
     }
 
     # The _chroot directory

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",

--- a/spec/expected/connection/chroot-systemd-pid.txt
+++ b/spec/expected/connection/chroot-systemd-pid.txt
@@ -7,10 +7,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+PIDFile=/var/opt/run/stunnel.pid
+ExecStartPre=-/usr/bin/mkdir -p /var/opt/run
+ExecStartPre=/usr/bin/chown stunnel:stunnel /var/opt/run
 ExecStartPre=/bin/bash -c 'if test -f /var/stunnel/var/opt/run/stunnel.pid; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/stunnel/var/opt/run/stunnel.pid; fi'
 ExecStartPre=/usr/bin/rm -f /var/stunnel/var/opt/run/stunnel.pid
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/spec/expected/connection/chroot-systemd.txt
+++ b/spec/expected/connection/chroot-systemd.txt
@@ -7,10 +7,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+PIDFile=/var/run/stunnel/stunnel.pid
+ExecStartPre=-/usr/bin/mkdir -p /var/run/stunnel
+ExecStartPre=/usr/bin/chown stunnel:stunnel /var/run/stunnel
 ExecStartPre=/bin/bash -c 'if test -f /var/stunnel/var/run/stunnel/stunnel.pid; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/stunnel/var/run/stunnel/stunnel.pid; fi'
 ExecStartPre=/usr/bin/rm -f /var/stunnel/var/run/stunnel/stunnel.pid
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/spec/expected/connection/nonchroot-systemd.txt
+++ b/spec/expected/connection/nonchroot-systemd.txt
@@ -7,10 +7,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+PIDFile=/var/run/stunnel/stunnel.pid
+ExecStartPre=-/usr/bin/mkdir -p /var/run/stunnel
+ExecStartPre=/usr/bin/chown stunnel:stunnel /var/run/stunnel
 ExecStartPre=/bin/bash -c 'if test -f /var/run/stunnel/stunnel.pid; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F /var/run/stunnel/stunnel.pid; fi'
 ExecStartPre=/usr/bin/rm -f /var/run/stunnel/stunnel.pid
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/spec/expected/instance/chroot-sel-systemd.txt
+++ b/spec/expected/instance/chroot-sel-systemd.txt
@@ -9,6 +9,7 @@ Wants=network-online.target
 Type=simple
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_sel.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/spec/expected/instance/chroot-systemd.txt
+++ b/spec/expected/instance/chroot-systemd.txt
@@ -9,6 +9,7 @@ Wants=network-online.target
 Type=simple
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/spec/expected/instance/non_chroot_el6_stunnel.conf.txt
+++ b/spec/expected/instance/non_chroot_el6_stunnel.conf.txt
@@ -1,0 +1,19 @@
+setgid = stunnel
+setuid = stunnel
+debug = err
+syslog = no
+pid = /var/run/stunnel/stunnel_managed_by_puppet_nfs.pid
+engine = auto
+[nfs]
+connect = 2049
+accept = 20490
+client = no
+failover = rr
+key = /etc/pki/simp_apps/stunnel_nfs/x509/private/foo.example.com.pem
+cert = /etc/pki/simp_apps/stunnel_nfs/x509/public/foo.example.com.pub
+CAfile = /etc/pki/simp_apps/stunnel_nfs/x509/cacerts/cacerts.pem
+CRLpath = /etc/pki/simp_apps/stunnel_nfs/x509/crl
+ciphers = HIGH:-SSLv2
+verify = 2
+delay = no
+retry = no

--- a/spec/expected/instance/non_chroot_el7_stunnel.conf.txt
+++ b/spec/expected/instance/non_chroot_el7_stunnel.conf.txt
@@ -1,0 +1,23 @@
+setgid = stunnel
+setuid = stunnel
+debug = err
+syslog = no
+foreground = yes
+pid =
+engine = auto
+fips = yes
+[nfs]
+connect = 2049
+accept = 20490
+client = no
+failover = rr
+key = /etc/pki/simp_apps/stunnel_nfs/x509/private/foo.example.com.pem
+cert = /etc/pki/simp_apps/stunnel_nfs/x509/public/foo.example.com.pub
+CAfile = /etc/pki/simp_apps/stunnel_nfs/x509/cacerts/cacerts.pem
+CRLpath = /etc/pki/simp_apps/stunnel_nfs/x509/crl
+ciphers = HIGH:-SSLv2
+verify = 2
+delay = no
+retry = no
+renegotiation = yes
+reset = yes

--- a/spec/expected/instance/nonchroot-systemd.txt
+++ b/spec/expected/instance/nonchroot-systemd.txt
@@ -9,6 +9,7 @@ Wants=network-online.target
 Type=simple
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_nfs.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/templates/connection_systemd.erb
+++ b/templates/connection_systemd.erb
@@ -7,6 +7,11 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+<% if @_pid -%>
+PIDFile=<%= @_pid %>
+ExecStartPre=-/usr/bin/mkdir -p <%= File.dirname(@_pid) %>
+ExecStartPre=/usr/bin/chown <%= @setuid %>:<%= @setgid %> <%= File.dirname(@_pid) %>
+<% end -%>
 <% if @_chroot -%>
 ExecStartPre=/bin/bash -c 'if test -f <%= @_chroot %><%= @_legacy_pid %>; then /usr/bin/pkill -f "stunnel /etc/stunnel/stunnel.conf" -F <%= @_chroot %><%= @_legacy_pid %>; fi'
 ExecStartPre=/usr/bin/rm -f <%= @_chroot %><%= @_legacy_pid %>
@@ -16,6 +21,7 @@ ExecStartPre=/usr/bin/rm -f <%= @_legacy_pid %>
 <% end -%>
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/templates/instance_systemd.erb
+++ b/templates/instance_systemd.erb
@@ -7,8 +7,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+<% if @_pid -%>
+PIDFile=<%= @_pid %>
+ExecStartPre=-/usr/bin/mkdir -p <%= File.dirname(@_pid) %>
+ExecStartPre=/usr/bin/chown <%= @setuid %>:<%= @setgid %> <%= File.dirname(@_pid) %>
+<% end -%>
 ExecStart=/usr/bin/stunnel /etc/stunnel/stunnel_managed_by_puppet_<%= @_safe_name %>.conf
 KillMode=process
+PrivateTmp=yes
 LimitNOFILE=1048576
 LimitNPROC=infinity
 Restart=on-failure

--- a/templates/instance_systemd.erb
+++ b/templates/instance_systemd.erb
@@ -15,3 +15,13 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
+<% if @systemd_wantedby -%>
+<%   @systemd_wantedby.each do |wanted| -%>
+WantedBy=<%= wanted %>
+<%   end -%>
+<% end -%>
+<% if @systemd_requiredby -%>
+<%   @systemd_requiredby.each do |required| -%>
+RequiredBy=<%= required %>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
- Added two new parameters to the stunnel::instance define:
  - systemd_wantedby: sent to the WantedBy systemd unit install
    directive
  - systemd_requiredby: sent to the RequiredBy systemd unit install
    directive
  - These should allow ordering during boot. For example, if you have
    NFS set up over stunnel, you want stunnel to start before NFS.

SIMP-4636 #close