### PR TITLE
(SIMP-4922) Fix service name for stunnel

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,6 +15,9 @@ fixtures:
     pki: https://github.com/simp/pupmod-simp-pki
     # used in the acceptance test
     selinux: https://github.com/simp/pupmod-simp-selinux
+    vox_selinux:
+      repo: https://github.com/simp/pupmod-voxpupuli-selinux
+      branch: simp-master
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Tue Jul 07 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.2
+* Tue Jul 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.2
 - Fix the service name used by stunnel so that tcpwrappers would not
   incorrectly drop connections.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Jul 07 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.2
+- Fix the service name used by stunnel so that tcpwrappers would not
+  incorrectly drop connections.
+
 * Mon Apr 23 2018 Jeanne Greulich  <jeanne.greulich@onyxpoint.com> - 6.3.2
 - Updated selinux settings in acceptance tests to reflect removal of
   simp_options::selinux setting and use selinux::ensure setting.

--- a/manifests/connection.pp
+++ b/manifests/connection.pp
@@ -317,6 +317,7 @@ define stunnel::connection (
     include '::tcpwrappers'
 
     tcpwrappers::allow { "allow_stunnel_${name}":
+      svc     => $name,
       pattern => nets2ddq($trusted_nets)
     }
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -500,7 +500,8 @@ define stunnel::instance(
     include '::tcpwrappers'
 
     tcpwrappers::allow { "allow_stunnel_${_safe_name}":
-      pattern => nets2ddq($trusted_nets)
+      pattern => nets2ddq($trusted_nets),
+      svc     => $_safe_name
     }
   }
 

--- a/spec/acceptance/suites/default/00_instances_spec.rb
+++ b/spec/acceptance/suites/default/00_instances_spec.rb
@@ -29,13 +29,6 @@ describe 'instance' do
       'simp_options::trusted_nets' => ['ANY']
     }}
 
-    context 'it should set up SSH Password access' do
-      on(host, %(sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config))
-      on(host, %(service sshd restart))
-      on(host, 'service firewalld stop ||:', :accept_all_exit_codes => true)
-      on(host, 'service iptables stop ||:', :accept_all_exit_codes => true)
-    end
-
     # This test verifies the validity of basic stunnel configurations
     # and ensures multiple connections can co-exist as advertised. It
     # does not test stunnel itself.

--- a/spec/acceptance/suites/default/20_connectivity_spec.rb
+++ b/spec/acceptance/suites/default/20_connectivity_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper_acceptance'
+
+test_name 'instance connectivity'
+
+describe 'instance connectivity' do
+
+  if hosts.count < 2
+    it 'only runs with more than one host' do
+      skip('You need at least two hosts in your nodeset to run this test')
+    end
+  else
+    let(:manifest) { <<-EOF
+      stunnel::instance { 'mysvc':
+        client  => false,
+        connect => [1234],
+        accept  => 12345
+      }
+
+      stunnel::instance { 'mysvc-client':
+        client  => true,
+        connect => ['#{server_fqdn}:12345'],
+        accept  => 1235
+      }
+      EOF
+    }
+
+    let(:hieradata) {{
+      'simp_options::pki'          => true,
+      'simp_options::pki::source'  => '/etc/pki/simp-testing/pki/',
+      'simp_options::trusted_nets' => [client_fqdn]
+    }}
+
+    server = hosts[0]
+    client = hosts[1]
+
+    let(:server_fqdn) { fact_on(server, 'fqdn') }
+    let(:client_fqdn) { fact_on(client, 'fqdn') }
+
+    context 'set up a bi-directional connection set' do
+      hosts.each do |host|
+        context "on #{host}" do
+          it 'should apply with no errors' do
+            set_hieradata_on(host, hieradata)
+            apply_manifest_on(host, manifest)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, catch_changes: true)
+          end
+
+          it 'should set up netcat to listen' do
+            host.install_package('nc')
+            on(host, 'nc -k --listen 1234 > /tmp/ncout.txt 2>&1 &')
+          end
+        end
+      end
+    end
+
+    context 'test a passed message' do
+      it 'should send from the client' do
+        on(client, %(/bin/echo "#{client_fqdn}" | nc localhost 1235))
+        output = on(server, 'tail -n1 /tmp/ncout.txt').stdout.strip
+
+        expect(output).to eq client_fqdn
+      end
+    end
+  end
+end


### PR DESCRIPTION
The stunnel service name was not being set correctly which resulted in
tcpwrappers settings that did not allow connections.

Added a test to explicitly test connectivity behind stunnel connections.

SIMP-5074 #close