### PR TITLE
(SIMP-5302) updated $app_pki_external_source type

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,7 @@ default:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
   script:
     - bundle exec rake beaker:suites[default]
 
@@ -204,6 +204,6 @@ default-fips:
   <<: *setup_bundler_env
   variables:
     BEAKER_fips: 'yes'
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
   script:
     - bundle exec rake beaker:suites[default]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.3.3
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Tue Jul 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.3.2
 - Fix the service name used by stunnel so that tcpwrappers would not
   incorrectly drop connections.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -116,7 +116,7 @@
 class stunnel::config (
   Variant[Enum['simp'],Boolean]  $pki                     = $::stunnel::pki,
   Stdlib::Absolutepath           $app_pki_dir             = $::stunnel::app_pki_dir,
-  Stdlib::Absolutepath           $app_pki_external_source = $::stunnel::app_pki_external_source,
+  String                         $app_pki_external_source = $::stunnel::app_pki_external_source,
   Stdlib::Absolutepath           $app_pki_key             = $::stunnel::app_pki_key,
   Stdlib::Absolutepath           $app_pki_cert            = $::stunnel::app_pki_cert,
   Stdlib::Absolutepath           $app_pki_ca_dir          = $::stunnel::app_pki_ca_dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@
 #
 class stunnel (
   Stdlib::Absolutepath          $app_pki_dir             = '/etc/pki/simp_apps/stunnel/x509',
-  Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                        $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath          $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",
   Stdlib::Absolutepath          $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
   Stdlib::Absolutepath          $app_pki_ca_dir          = "${app_pki_dir}/cacerts",

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -205,7 +205,7 @@ define stunnel::instance(
   Boolean                                     $tcpwrappers             = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }),
   Variant[Enum['simp'],Boolean]               $pki                     = simplib::lookup('simp_options::pki', { 'default_value' => false }),
   Stdlib::Absolutepath                        $app_pki_dir             = "/etc/pki/simp_apps/stunnel_${name}/x509",
-  Stdlib::Absolutepath                        $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                                      $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath                        $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",
   Stdlib::Absolutepath                        $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
   Stdlib::Absolutepath                        $app_pki_ca_dir          = "${app_pki_dir}/cacerts",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated stunnel
SIMP-5302 #close