### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,11 +8,7 @@ fixtures:
     # No idea why, it may be because Puppet sees a custom backend and loads all
     # of the global parts.
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.1
+- Expanded the upper limit of the concat and stdlib Puppet module versions
+- Updated URLs in the README.md
+
 * Mon Jan 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.4.0
 - Add ability for users to override stunnel::connection and stunnel::instance
   options either globally or by specific identified instance.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ a compliance-management framework built on Puppet.
 If you find any issues, they can be submitted to our
 [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 This module is optimally designed for use within a larger SIMP ecosystem, but it
 can be used independently:
@@ -120,7 +120,7 @@ operating systems have not been tested and results cannot be guaranteed.
 
 # Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 Visit the project homepage on [GitHub](https://simp-project.com)
 and look at our issues on  [JIRA](https://simp-project.atlassian.net/).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
+      "version_requirement": ">= 2.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/haveged",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the concat and stdlib Puppet module versions
- Updated URLs in the README.md

SIMP-6213 #comment pupmod-simp-stunnel