### PR TITLE
(SIMP-6115) Use namespaced simplib::validate_array_member

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.2
+- Use simplib::nets2ddq in lieu of simplib's deprecated Puppet 3 nets2ddq
+- Use Puppet Integer instead of simplib's deprecated Puppet 3 to_integer
+- Use Puppet String instead of simplib's deprecated Puppet 3 to_string
+- Use simplib::validate_array_member in lieu of simplib's deprecated
+  Puppet 3 validate_array_member
+
 * Wed Mar 06 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 6.4.1
 - If statement evaluating boolean parameter prevented RNDoverwrite being
   set to 'no'. Fixed logic, updated tests, and changed default value

--- a/manifests/connection.pp
+++ b/manifests/connection.pp
@@ -248,7 +248,7 @@ define stunnel::connection (
   Boolean                                     $tcpwrappers             = pick(simplib::dlookup('stunnel::connection', 'tcpwrappers', $name, {'default_value' => undef }), simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }))
 ) {
 
-  $_dport = split(to_string($accept),':')[-1]
+  $_dport = split(String($accept),':')[-1]
 
   stunnel::instance::reserve_port { $_dport: }
 
@@ -257,26 +257,26 @@ define stunnel::connection (
   # Validation for RHEL6/7 Options. Defaulting to 7.
   if ($facts['os']['name'] in ['RedHat','CentOS','OracleLinux']) and ($facts['os']['release']['major'] < '7') {
     if $::stunnel::fips {
-      if $ssl_version { validate_array_member($ssl_version,['TLSv1']) }
+      if $ssl_version { simplib::validate_array_member($ssl_version,['TLSv1']) }
     }
     else {
-      if $ssl_version { validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1']) }
+      if $ssl_version { simplib::validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1']) }
     }
     if $protocol {
-      validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','smtp'])
+      simplib::validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','smtp'])
     }
   }
   else {
     if $::stunnel::fips {
-      if $ssl_version { validate_array_member($ssl_version,['TLSv1','TLSv1.1','TLSv1.2']) }
+      if $ssl_version { simplib::validate_array_member($ssl_version,['TLSv1','TLSv1.1','TLSv1.2']) }
     }
     else {
       if $ssl_version {
-        validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1','TLSv1.1','TLSv1.2'])
+        simplib::validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1','TLSv1.1','TLSv1.2'])
       }
     }
     if $protocol {
-      validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','proxy','smtp'])
+      simplib::validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','proxy','smtp'])
     }
   }
 
@@ -319,7 +319,7 @@ define stunnel::connection (
 
     iptables::listen::tcp_stateful { "allow_stunnel_${name}":
       trusted_nets => $trusted_nets,
-      dports       => [to_integer($_dport)]
+      dports       => [Integer($_dport)]
     }
   }
 
@@ -328,7 +328,7 @@ define stunnel::connection (
 
     tcpwrappers::allow { "allow_stunnel_${name}":
       svc     => $name,
-      pattern => nets2ddq($trusted_nets)
+      pattern => simplib::nets2ddq($trusted_nets)
     }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -278,7 +278,7 @@ define stunnel::instance(
   Optional[Array[String]]                     $systemd_requiredby      = simplib::dlookup('stunnel::instance', 'systemd_requiredby', $name, { 'default_value' => undef }),
 ){
   $_safe_name = regsubst($name, '(/|\s)', '__')
-  $_dport = split(to_string($accept),':')[-1]
+  $_dport = split(String($accept),':')[-1]
 
   $_on_systemd = 'systemd' in $facts['init_systems']
 
@@ -291,26 +291,26 @@ define stunnel::instance(
   # Validation for RHEL6/7 Options. Defaulting to 7.
   if ($facts['os']['name'] in ['Red Hat','CentOS']) and ($facts['os']['release']['major'] < '7') {
     if $fips {
-      if $ssl_version { validate_array_member($ssl_version,['TLSv1']) }
+      if $ssl_version { simplib::validate_array_member($ssl_version,['TLSv1']) }
     }
     else {
-      if $ssl_version { validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1']) }
+      if $ssl_version { simplib::validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1']) }
     }
     if $protocol {
-      validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','smtp'])
+      simplib::validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','smtp'])
     }
   }
   else {
     if $fips {
-      if $ssl_version { validate_array_member($ssl_version,['TLSv1','TLSv1.1','TLSv1.2']) }
+      if $ssl_version { simplib::validate_array_member($ssl_version,['TLSv1','TLSv1.1','TLSv1.2']) }
     }
     else {
       if $ssl_version {
-        validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1','TLSv1.1','TLSv1.2'])
+        simplib::validate_array_member($ssl_version,['all','SSLv2','SSLv3','TLSv1','TLSv1.1','TLSv1.2'])
       }
     }
     if $protocol {
-      validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','proxy','smtp'])
+      simplib::validate_array_member($protocol,['cifs','connect','imap','nntp','pgsql','pop3','proxy','smtp'])
     }
   }
 
@@ -506,7 +506,7 @@ define stunnel::instance(
 
     iptables::listen::tcp_stateful { "allow_stunnel_${_safe_name}":
       trusted_nets => $trusted_nets,
-      dports       => [to_integer($_dport)]
+      dports       => [Integer($_dport)]
     }
   }
 
@@ -514,7 +514,7 @@ define stunnel::instance(
     include '::tcpwrappers'
 
     tcpwrappers::allow { "allow_stunnel_${_safe_name}":
-      pattern => nets2ddq($trusted_nets),
+      pattern => simplib::nets2ddq($trusted_nets),
       svc     => $_safe_name
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-stunnel",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Use simplib::validate_array_member in lieu of simplib's deprecated
  Puppet 3 validate_array_member
- Use simplib::nets2ddq in lieu of simplib's deprecated Puppet 3 nets2ddq
- Use Puppet Integer instead of simplib's deprecated Puppet 3 to_integer
- Use Puppet String instead of simplib's deprecated Puppet 3 to_string

SIMP-6115 #close