### PR TITLE
(SIMP-6949) Fixtures pinned to wrong puppet-systemd branch

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -22,9 +22,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib
-    systemd:
-      repo: https://github.com/simp/puppet-systemd
-      branch: simp-master
+    systemd: https://github.com/simp/puppet-systemd
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
     stunnel: "#{source_dir}"


### PR DESCRIPTION
SIMP-6949 #comment pupmod-simp-stunnel