### PR TITLE
(SIMP-10176) stunnel Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,7 @@
 fixtures:
   repositories:
     auditd: https://github.com/simp/pupmod-simp-auditd.git
-    augeas_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
+    augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
     augeasproviders_core: https://github.com/simp/augeasproviders_core.git
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,3 +368,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Remove check for Puppet >=6 in .fixtures.yml
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-stunnel acceptance tests configured
SIMP-10176 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666