### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -22,6 +22,5 @@ fixtures:
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     systemd: https://github.com/simp/puppet-systemd.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
   symlinks:
     stunnel: "#{source_dir}"

--- a/manifests/connection.pp
+++ b/manifests/connection.pp
@@ -184,9 +184,6 @@
 # @param firewall
 #   Include the SIMP ``iptables`` module to manage the firewall
 #
-# @param tcpwrappers
-#   Include the SIMP ``tcpwrappers`` module to manage tcpwrappers
-#
 # All other configuration options can be found in the stunnel man pages
 # @see stunnel.conf(5)
 # @see stunnel.conf(8)
@@ -236,7 +233,6 @@ define stunnel::connection (
   Optional[Integer]                           $timeout_idle            = simplib::dlookup('stunnel::connection', 'timeout_idle', $name, { 'default_value' => undef }),
   Simplib::Netlist                            $trusted_nets            = pick(simplib::dlookup('stunnel::connection', 'trusted_nets', $name, { 'default_value' => undef }), simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] })),
   Boolean                                     $firewall                = pick(simplib::dlookup('stunnel::connection', 'firewall', $name, { 'default_value' => undef }), simplib::lookup('simp_options::firewall', { 'default_value' => false })),
-  Boolean                                     $tcpwrappers             = pick(simplib::dlookup('stunnel::connection', 'tcpwrappers', $name, { 'default_value' => undef }), simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }))
 ) {
   $_dport = split(String($accept),':')[-1]
 
@@ -300,13 +296,4 @@ define stunnel::connection (
     }
   }
 
-  if !$client and $tcpwrappers {
-    include 'tcpwrappers'
-
-    tcpwrappers::allow { "allow_stunnel_${name}":
-      svc     => $name,
-      # Needed to work around a bug in the version of stunnel shipped with EL7.9
-      pattern => 'ALL',
-    }
-  }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -69,9 +69,6 @@
 # @param firewall
 #   Include the SIMP ``iptables`` module to manage the firewall
 #
-# @param tcpwrappers
-#   Include the SIMP ``tcpwrappers`` module to manage tcpwrappers
-#
 # @param pki
 #   * If ``simp``, include SIMP's ``pki`` module and use ``pki::copy`` to
 #     manage application certs in ``/etc/pki/simp_apps/stunnel/x509``
@@ -213,7 +210,6 @@ define stunnel::instance (
   Simplib::Netlist                            $trusted_nets            = simplib::dlookup('stunnel::instance', 'trusted_nets', $name, { 'default_value' => simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }) }),
   Boolean                                     $firewall                = simplib::dlookup('stunnel::instance', 'firewall', $name, { 'default_value' => simplib::lookup('simp_options::firewall', { 'default_value' => false }) }),
   Boolean                                     $haveged                 = simplib::dlookup('stunnel::instance', 'haveged', $name, { 'default_value' => simplib::lookup('simp_options::haveged', { 'default_value' => true }) }),
-  Boolean                                     $tcpwrappers             = simplib::dlookup('stunnel::instance', 'tcpwrappers', $name, { 'default_value' => simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }) }),
   Variant[Enum['simp'],Boolean]               $pki                     = simplib::dlookup('stunnel::instance', 'pki', $name, { 'default_value' => simplib::lookup('simp_options::pki', { 'default_value' => false }) }),
   Stdlib::Absolutepath                        $app_pki_dir             = simplib::dlookup('stunnel::instance', 'app_pki_dir', $name, { 'default_value' => "/etc/pki/simp_apps/stunnel_${name}/x509" }),
   String                                      $app_pki_external_source = simplib::dlookup('stunnel::instance', 'app_pki_external_source', $name, { 'default_value' => simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }) }),
@@ -463,16 +459,6 @@ define stunnel::instance (
     iptables::listen::tcp_stateful { "allow_stunnel_${_safe_name}":
       trusted_nets => $trusted_nets,
       dports       => [Integer($_dport)],
-    }
-  }
-
-  if !$client and $tcpwrappers {
-    include 'tcpwrappers'
-
-    tcpwrappers::allow { "allow_stunnel_${_safe_name}":
-      # Needed to work around a bug in the version of stunnel shipped with EL7.9
-      pattern => 'ALL',
-      svc     => $_safe_name,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -39,10 +39,6 @@
     {
       "name": "simp/simplib",
       "version_requirement": ">= 4.9.0 < 5.0.0"
-    },
-    {
-      "name": "simp/tcpwrappers",
-      "version_requirement": ">= 6.2.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/defines/connection_spec.rb
+++ b/spec/defines/connection_spec.rb
@@ -62,22 +62,6 @@ describe 'stunnel::connection' do
           }
         end
 
-        context 'using tcpwrappers' do
-          let(:title) { 'nfs' }
-          let(:params) do
-            {
-              tcpwrappers: true,
-              client: false,
-              connect: [2049],
-              accept: 20_490,
-              trusted_nets: ['any'],
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_tcpwrappers__allow("allow_stunnel_#{title}").with_pattern(['ALL']) }
-        end
-
         context 'setting ocsp options' do
           let(:title) { 'nfs' }
           let(:params) do
@@ -218,7 +202,6 @@ describe 'stunnel::connection' do
                 sni: 'global.sni.server',
                 ssl_version: 'TLSv1',
                 stack: 1024,
-                tcpwrappers: true,
                 timeout_busy: 5,
                 timeout_close: 10,
                 timeout_connect: 15,
@@ -260,7 +243,6 @@ describe 'stunnel::connection' do
                 sni: 'global.sni.server',
                 ssl_version: 'TLSv1',
                 stack: 1024,
-                tcpwrappers: true,
                 timeout_busy: 5,
                 timeout_close: 10,
                 timeout_connect: 15,

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -39,12 +39,11 @@ describe 'stunnel::instance' do
         it { is_expected.to create_stunnel__instance__reserve_port('20490') }
         it { is_expected.to contain_class('stunnel::install') }
         it { is_expected.not_to create_iptables__listen__tcp_stateful('allow_stunnel_nfs') }
-        it { is_expected.not_to create_tcpwrappers__allow('allow_stunnel_nfs') }
         it { is_expected.not_to create_pki__copy('stunnel_nfs') }
         it { is_expected.not_to create_file('/var/stunnel_nfs') }
       end
 
-      context 'with firewall, tcpwrappers, pki, fips true' do
+      context 'with firewall, pki, fips true' do
         let(:params) do
           {
             client:       false,
@@ -52,7 +51,6 @@ describe 'stunnel::instance' do
             accept:       20_490,
             trusted_nets: ['any'],
             firewall:     true,
-            tcpwrappers:  true,
             pki:          true,
             fips:         true,
           }
@@ -80,7 +78,6 @@ describe 'stunnel::instance' do
             dports:       [params[:accept].to_s.split(':')[-1]],
           )
         }
-        it { is_expected.to create_tcpwrappers__allow('allow_stunnel_nfs').with_pattern(['ALL']) }
         it { is_expected.to create_pki__copy('stunnel_nfs') }
         it { is_expected.to contain_class('stunnel::install') }
       end
@@ -409,7 +406,6 @@ describe 'stunnel::instance' do
               syslog: true,
               systemd_wantedby: [ 'some.service' ],
               systemd_requiredby: [ 'someother.service' ],
-              tcpwrappers: true,
               timeout_busy: 5,
               timeout_close: 10,
               timeout_connect: 15,
@@ -472,7 +468,6 @@ describe 'stunnel::instance' do
               syslog: true,
               systemd_wantedby: [ 'some.service' ],
               systemd_requiredby: [ 'someother.service' ],
-              tcpwrappers: true,
               timeout_busy: 5,
               timeout_close: 10,
               timeout_connect: 15,

--- a/spec/fixtures/hieradata/defined_type_global_override.yaml
+++ b/spec/fixtures/hieradata/defined_type_global_override.yaml
@@ -29,7 +29,6 @@ stunnel::connection::session_cache_timeout: 1000
 stunnel::connection::sni: 'global.sni.server'
 stunnel::connection::ssl_version: 'TLSv1'
 stunnel::connection::stack: 1024
-stunnel::connection::tcpwrappers: true
 stunnel::connection::timeout_busy: 5
 stunnel::connection::timeout_close: 10
 stunnel::connection::timeout_connect: 15
@@ -89,7 +88,6 @@ stunnel::instance::stunnel_debug: 'info'
 stunnel::instance::syslog: true
 stunnel::instance::systemd_wantedby: [ 'some.service' ]
 stunnel::instance::systemd_requiredby: [ 'someother.service' ]
-stunnel::instance::tcpwrappers: true
 stunnel::instance::timeout_busy: 5
 stunnel::instance::timeout_close: 10
 stunnel::instance::timeout_connect: 15


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.