### PR TITLE
Cleanup for 9.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -8,21 +8,11 @@
 #
 # ==============================================================================
 #
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5     2022-12 (LTS)
-# PE 2021.Y     7.x      2.7     Quarterly updates
-#
-# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# ==============================================================================
-#
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -32,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -44,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -58,10 +48,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.4"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: |
           bundle show
@@ -72,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: 'Install Ruby 2.7'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -85,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: 'Install Ruby 2.7'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -120,16 +110,16 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
-  
+
   acceptance:
     runs-on:
       - ubuntu-latest
     strategy:
       matrix:
         node:
-          - almalinux8
+          - almalinux9
           - almalinux10
       fail-fast: false
     steps:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 9.0.0
+- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
+- Point `issues_url` at GitHub Issues
+- Drop end-of-life OS support (CentOS 8, EL7); list EL10 across all supported distros
+- Allow newer SIMP module dependencies (see metadata.json diff)
+- Sync Gemfile with current puppetsync baseline (adds OpenVox to test gems)
+- Drop Puppet 7 / Ruby 2.7 from GitHub Actions; use Ruby 3.2.11 with OpenVox 8 and 3.4.9 elsewhere
+
 * Mon May 11 2026 Steven Pritchard <steve@sicura.us> - 8.0.0
 - Remove unmaintained Compliance Engine data
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,16 @@ group :syntax do
 end
 
 group :test do
-  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
+  openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
   major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
   gem 'hiera-puppet-helper'
-  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   # renovate: datasource=rubygems versioning=ruby
   gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  gem 'puppet', puppet_version
+  # Temporarily include both openvox and puppet gems until the puppet dependency is removed from other gems
+  ['openvox', 'puppet'].each do |gem_name|
+    gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
+  end
   gem 'puppetlabs_spec_helper', '~> 8.0.0'
   gem 'puppet-strings'
   gem 'rake'

--- a/data/os/RedHat-10.yaml
+++ b/data/os/RedHat-10.yaml
@@ -1,0 +1,2 @@
+---
+stunnel::config::crypto_backend: 'engine'

--- a/data/os/RedHat-10.yaml
+++ b/data/os/RedHat-10.yaml
@@ -1,2 +1,2 @@
 ---
-stunnel::config::crypto_backend: 'engine'
+stunnel::config::crypto_backend: 'none'

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "simp-stunnel",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "author": "SIMP Team",
   "summary": "manages stunnel with PKI support",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-stunnel",
   "project_page": "https://github.com/simp/pupmod-simp-stunnel",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-stunnel/issues",
   "tags": [
     "simp",
     "stunnel",
@@ -30,15 +30,15 @@
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 6.5.3 < 8.0.0"
+      "version_requirement": ">= 6.5.3 < 9.0.0"
     },
     {
       "name": "simp/pki",
-      "version_requirement": ">= 6.2.0 < 7.0.0"
+      "version_requirement": ">= 6.2.0 < 8.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     },
     {
       "name": "simp/tcpwrappers",
@@ -88,8 +88,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/centos9.yml
+++ b/spec/acceptance/nodesets/centos9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/centos9s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/hiera_data_helper'
 
 describe 'stunnel::instance' do
   def mock_selinux_false_facts(os_facts)

--- a/spec/expected/instance/non_chroot_el10_stunnel.conf.txt
+++ b/spec/expected/instance/non_chroot_el10_stunnel.conf.txt
@@ -1,0 +1,23 @@
+setgid = stunnel
+setuid = stunnel
+debug = err
+syslog = no
+foreground = yes
+pid =
+engine = auto
+fips = yes
+RNDoverwrite = yes
+[nfs]
+connect = 2049
+accept = 20490
+client = no
+failover = rr
+key = /etc/pki/simp_apps/stunnel_nfs/x509/private/foo.example.com.pem
+cert = /etc/pki/simp_apps/stunnel_nfs/x509/public/foo.example.com.pub
+CAfile = /etc/pki/simp_apps/stunnel_nfs/x509/cacerts/cacerts.pem
+ciphers = HIGH:-SSLv2
+sslVersion = TLSv1.2
+verify = 2
+delay = no
+renegotiation = yes
+reset = yes

--- a/spec/expected/instance/non_chroot_el10_stunnel.conf.txt
+++ b/spec/expected/instance/non_chroot_el10_stunnel.conf.txt
@@ -4,7 +4,6 @@ debug = err
 syslog = no
 foreground = yes
 pid =
-engine = auto
 fips = yes
 RNDoverwrite = yes
 [nfs]


### PR DESCRIPTION
## Summary

Cleanup pass to bring this module in line with the current SIMP baseline. No API/behavior changes.

- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
- Point `issues_url` at GitHub Issues
- Drop end-of-life OS support (CentOS 8, EL7); list EL10 across all supported distros
- Allow newer SIMP module dependencies (see metadata.json diff)
- Sync Gemfile with current puppetsync baseline (adds OpenVox to test gems)
- Drop Puppet 7 / Ruby 2.7 from GitHub Actions; use Ruby 3.2.11 with OpenVox 8 and 3.4.9 elsewhere

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)
